### PR TITLE
Remove custom batch normalization layer.

### DIFF
--- a/keras_resnet/__init__.py
+++ b/keras_resnet/__init__.py
@@ -1,5 +1,2 @@
-from . import layers
-
-custom_objects = {
-    'BatchNormalization': layers.BatchNormalization,
-}
+# Keep this for compatibility reasons.
+custom_objects = {}

--- a/keras_resnet/blocks/_1d.py
+++ b/keras_resnet/blocks/_1d.py
@@ -23,7 +23,7 @@ def basic_1d(
     kernel_size=3,
     numerical_name=False,
     stride=None,
-    freeze_bn=False
+    trainable_bn=True
 ):
     """
     A one-dimensional basic block.
@@ -40,7 +40,7 @@ def basic_1d(
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -81,10 +81,10 @@ def basic_1d(
             **parameters
         )(y)
         
-        y = keras_resnet.layers.BatchNormalization(
+        y = tf.keras.layers.BatchNormalization(
             axis=axis,
             epsilon=1e-5,
-            freeze=freeze_bn,
+            trainable=trainable_bn,
             name="bn{}{}_branch2a".format(stage_char, block_char)
         )(y)
         
@@ -106,10 +106,10 @@ def basic_1d(
             **parameters
         )(y)
         
-        y = keras_resnet.layers.BatchNormalization(
+        y = tf.keras.layers.BatchNormalization(
             axis=axis,
             epsilon=1e-5,
-            freeze=freeze_bn,
+            trainable=trainable_bn,
             name="bn{}{}_branch2b".format(stage_char, block_char)
         )(y)
 
@@ -123,10 +123,10 @@ def basic_1d(
                 **parameters
             )(x)
 
-            shortcut = keras_resnet.layers.BatchNormalization(
+            shortcut = tf.keras.layers.BatchNormalization(
                 axis=axis,
                 epsilon=1e-5,
-                freeze=freeze_bn,
+                trainable=trainable_bn,
                 name="bn{}{}_branch1".format(stage_char, block_char)
             )(shortcut)
         else:
@@ -153,7 +153,7 @@ def bottleneck_1d(
     kernel_size=3,
     numerical_name=False,
     stride=None,
-    freeze_bn=False
+    trainable_bn=True
 ):
     """
     A one-dimensional bottleneck block.
@@ -170,7 +170,7 @@ def bottleneck_1d(
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -203,10 +203,10 @@ def bottleneck_1d(
             **parameters
         )(x)
 
-        y = keras_resnet.layers.BatchNormalization(
+        y = tf.keras.layers.BatchNormalization(
             axis=axis,
             epsilon=1e-5,
-            freeze=freeze_bn,
+            trainable=trainable_bn,
             name="bn{}{}_branch2a".format(stage_char, block_char)
         )(y)
 
@@ -228,10 +228,10 @@ def bottleneck_1d(
             **parameters
         )(y)
 
-        y = keras_resnet.layers.BatchNormalization(
+        y = tf.keras.layers.BatchNormalization(
             axis=axis,
             epsilon=1e-5,
-            freeze=freeze_bn,
+            trainable=trainable_bn,
             name="bn{}{}_branch2b".format(stage_char, block_char)
         )(y)
 
@@ -248,10 +248,10 @@ def bottleneck_1d(
             **parameters
         )(y)
 
-        y = keras_resnet.layers.BatchNormalization(
+        y = tf.keras.layers.BatchNormalization(
             axis=axis,
             epsilon=1e-5,
-            freeze=freeze_bn,
+            trainable=trainable_bn,
             name="bn{}{}_branch2c".format(stage_char, block_char)
         )(y)
 
@@ -265,10 +265,10 @@ def bottleneck_1d(
                 **parameters
             )(x)
 
-            shortcut = keras_resnet.layers.BatchNormalization(
+            shortcut = tf.keras.layers.BatchNormalization(
                 axis=axis,
                 epsilon=1e-5,
-                freeze=freeze_bn,
+                trainable=trainable_bn,
                 name="bn{}{}_branch1".format(stage_char, block_char)
             )(shortcut)
         else:

--- a/keras_resnet/blocks/_2d.py
+++ b/keras_resnet/blocks/_2d.py
@@ -23,7 +23,7 @@ def basic_2d(
     kernel_size=3,
     numerical_name=False,
     stride=None,
-    freeze_bn=False
+    trainable_bn=True
 ):
     """
     A two-dimensional basic block.
@@ -40,7 +40,7 @@ def basic_2d(
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -71,7 +71,7 @@ def basic_2d(
 
         y = tf.keras.layers.Conv2D(filters, kernel_size, strides=stride, use_bias=False, name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(y)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
@@ -79,12 +79,12 @@ def basic_2d(
 
         y = tf.keras.layers.Conv2D(filters, kernel_size, use_bias=False, name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         if block == 0:
             shortcut = tf.keras.layers.Conv2D(filters, (1, 1), strides=stride, use_bias=False, name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
 
-            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
+            shortcut = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
@@ -104,7 +104,7 @@ def bottleneck_2d(
     kernel_size=3,
     numerical_name=False,
     stride=None,
-    freeze_bn=False
+    trainable_bn=True
 ):
     """
     A two-dimensional bottleneck block.
@@ -121,7 +121,7 @@ def bottleneck_2d(
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -150,7 +150,7 @@ def bottleneck_2d(
     def f(x):
         y = tf.keras.layers.Conv2D(filters, (1, 1), strides=stride, use_bias=False, name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(x)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
@@ -158,18 +158,18 @@ def bottleneck_2d(
 
         y = tf.keras.layers.Conv2D(filters, kernel_size, use_bias=False, name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.Activation("relu", name="res{}{}_branch2b_relu".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.Conv2D(filters * 4, (1, 1), use_bias=False, name="res{}{}_branch2c".format(stage_char, block_char), **parameters)(y)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2c".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2c".format(stage_char, block_char))(y)
 
         if block == 0:
             shortcut = tf.keras.layers.Conv2D(filters * 4, (1, 1), strides=stride, use_bias=False, name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
 
-            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
+            shortcut = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 

--- a/keras_resnet/blocks/_3d.py
+++ b/keras_resnet/blocks/_3d.py
@@ -23,7 +23,7 @@ def basic_3d(
     kernel_size=3,
     numerical_name=False,
     stride=None,
-    freeze_bn=False
+    trainable_bn=True
 ):
     """
     A three-dimensional basic block.
@@ -40,7 +40,7 @@ def basic_3d(
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -71,7 +71,7 @@ def basic_3d(
 
         y = tf.keras.layers.Conv3D(filters, kernel_size, strides=stride, use_bias=False, name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(y)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
@@ -79,12 +79,12 @@ def basic_3d(
 
         y = tf.keras.layers.Conv3D(filters, kernel_size, use_bias=False, name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         if block == 0:
             shortcut = tf.keras.layers.Conv3D(filters, (1, 1), strides=stride, use_bias=False, name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
 
-            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
+            shortcut = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
@@ -104,7 +104,7 @@ def bottleneck_3d(
     kernel_size=3,
     numerical_name=False,
     stride=None,
-    freeze_bn=False
+    trainable_bn=True
 ):
     """
     A three-dimensional bottleneck block.
@@ -121,7 +121,7 @@ def bottleneck_3d(
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -150,7 +150,7 @@ def bottleneck_3d(
     def f(x):
         y = tf.keras.layers.Conv3D(filters, (1, 1), strides=stride, use_bias=False, name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(x)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
@@ -158,18 +158,18 @@ def bottleneck_3d(
 
         y = tf.keras.layers.Conv3D(filters, kernel_size, use_bias=False, name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.Activation("relu", name="res{}{}_branch2b_relu".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.Conv3D(filters * 4, (1, 1), use_bias=False, name="res{}{}_branch2c".format(stage_char, block_char), **parameters)(y)
 
-        y = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch2c".format(stage_char, block_char))(y)
+        y = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch2c".format(stage_char, block_char))(y)
 
         if block == 0:
             shortcut = tf.keras.layers.Conv3D(filters * 4, (1, 1), strides=stride, use_bias=False, name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
 
-            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
+            shortcut = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 

--- a/keras_resnet/blocks/_time_distributed_2d.py
+++ b/keras_resnet/blocks/_time_distributed_2d.py
@@ -23,7 +23,7 @@ def time_distributed_basic_2d(
     kernel_size=3,
     numerical_name=False,
     stride=None,
-    freeze_bn=False
+    trainable_bn=True
 ):
     """
 
@@ -41,7 +41,7 @@ def time_distributed_basic_2d(
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -73,7 +73,7 @@ def time_distributed_basic_2d(
 
         y = tf.keras.layers.TimeDistributed(tf.keras.layers.Conv2D(filters, kernel_size, strides=stride, use_bias=False, **parameters), name="res{}{}_branch2a".format(stage_char, block_char))(y)
 
-        y = tf.keras.layers.TimeDistributed(keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn), name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = tf.keras.layers.TimeDistributed(tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn), name="bn{}{}_branch2a".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.TimeDistributed(tf.keras.layers.Activation("relu"), name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
@@ -81,12 +81,12 @@ def time_distributed_basic_2d(
 
         y = tf.keras.layers.TimeDistributed(tf.keras.layers.Conv2D(filters, kernel_size, use_bias=False, **parameters), name="res{}{}_branch2b".format(stage_char, block_char))(y)
 
-        y = tf.keras.layers.TimeDistributed(keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn), name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = tf.keras.layers.TimeDistributed(tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn), name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         if block == 0:
             shortcut = tf.keras.layers.TimeDistributed(tf.keras.layers.Conv2D(filters, (1, 1), strides=stride, use_bias=False, **parameters), name="res{}{}_branch1".format(stage_char, block_char))(x)
 
-            shortcut = tf.keras.layers.TimeDistributed(keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn), name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
+            shortcut = tf.keras.layers.TimeDistributed(tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn), name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
@@ -106,7 +106,7 @@ def time_distributed_bottleneck_2d(
     kernel_size=3,
     numerical_name=False,
     stride=None,
-    freeze_bn=False
+    trainable_bn=True
 ):
     """
 
@@ -124,7 +124,7 @@ def time_distributed_bottleneck_2d(
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -154,7 +154,7 @@ def time_distributed_bottleneck_2d(
     def f(x):
         y = tf.keras.layers.TimeDistributed(tf.keras.layers.Conv2D(filters, (1, 1), strides=stride, use_bias=False, **parameters), name="res{}{}_branch2a".format(stage_char, block_char))(x)
 
-        y = tf.keras.layers.TimeDistributed(keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn), name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = tf.keras.layers.TimeDistributed(tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn), name="bn{}{}_branch2a".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.TimeDistributed(tf.keras.layers.Activation("relu"), name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
@@ -162,18 +162,18 @@ def time_distributed_bottleneck_2d(
 
         y = tf.keras.layers.TimeDistributed(tf.keras.layers.Conv2D(filters, kernel_size, use_bias=False, **parameters), name="res{}{}_branch2b".format(stage_char, block_char))(y)
 
-        y = tf.keras.layers.TimeDistributed(keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn), name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = tf.keras.layers.TimeDistributed(tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn), name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.TimeDistributed(tf.keras.layers.Activation("relu"), name="res{}{}_branch2b_relu".format(stage_char, block_char))(y)
 
         y = tf.keras.layers.TimeDistributed(tf.keras.layers.Conv2D(filters * 4, (1, 1), use_bias=False, **parameters), name="res{}{}_branch2c".format(stage_char, block_char))(y)
 
-        y = tf.keras.layers.TimeDistributed(keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn), name="bn{}{}_branch2c".format(stage_char, block_char))(y)
+        y = tf.keras.layers.TimeDistributed(tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn), name="bn{}{}_branch2c".format(stage_char, block_char))(y)
 
         if block == 0:
             shortcut = tf.keras.layers.TimeDistributed(tf.keras.layers.Conv2D(filters * 4, (1, 1), strides=stride, use_bias=False, **parameters), name="res{}{}_branch1".format(stage_char, block_char))(x)
 
-            shortcut = tf.keras.layers.TimeDistributed(tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn), name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
+            shortcut = tf.keras.layers.TimeDistributed(tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn), name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 

--- a/keras_resnet/layers/_batch_normalization.py
+++ b/keras_resnet/layers/_batch_normalization.py
@@ -13,6 +13,7 @@ class BatchNormalization(tf.keras.layers.BatchNormalization):
         self.trainable = not self.freeze
 
     def call(self, *args, **kwargs):
+        print(kwargs)
         # Force test mode if frozen, otherwise use default behaviour (i.e., training=None).
         if self.freeze:
             kwargs['training'] = False

--- a/keras_resnet/models/_1d.py
+++ b/keras_resnet/models/_1d.py
@@ -27,7 +27,7 @@ class ResNet1D(tf.keras.Model):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :param numerical_names: list of bool, same size as blocks, used to indicate whether names of layers should include numbers or letters
 
@@ -57,7 +57,7 @@ class ResNet1D(tf.keras.Model):
         block,
         include_top=True,
         classes=1000,
-        freeze_bn=True,
+        trainable_bn=True,
         numerical_names=None,
         *args,
         **kwargs
@@ -72,7 +72,7 @@ class ResNet1D(tf.keras.Model):
 
         x = tf.keras.layers.ZeroPadding1D(padding=3, name="padding_conv1")(inputs)
         x = tf.keras.layers.Conv1D(64, (7, 7), strides=(2, 2), use_bias=False, name="conv1")(x)
-        x = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn_conv1")(x)
+        x = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn_conv1")(x)
         x = tf.keras.layers.Activation("relu", name="conv1_relu")(x)
         x = tf.keras.layers.MaxPooling1D((3, 3), strides=(2, 2), padding="same", name="pool1")(x)
 
@@ -87,7 +87,7 @@ class ResNet1D(tf.keras.Model):
                     stage_id,
                     block_id,
                     numerical_name=(block_id > 0 and numerical_names[stage_id]),
-                    freeze_bn=freeze_bn
+                    trainable_bn=trainable_bn
                 )(x)
 
             features *= 2
@@ -118,7 +118,7 @@ class ResNet1D18(ResNet1D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -134,7 +134,7 @@ class ResNet1D18(ResNet1D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [2, 2, 2, 2]
 
@@ -144,7 +144,7 @@ class ResNet1D18(ResNet1D):
             block=keras_resnet.blocks.basic_1d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -162,7 +162,7 @@ class ResNet1D34(ResNet1D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -178,7 +178,7 @@ class ResNet1D34(ResNet1D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 6, 3]
 
@@ -188,7 +188,7 @@ class ResNet1D34(ResNet1D):
             block=keras_resnet.blocks.basic_1d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -206,7 +206,7 @@ class ResNet1D50(ResNet1D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -222,7 +222,7 @@ class ResNet1D50(ResNet1D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 6, 3]
 
@@ -235,7 +235,7 @@ class ResNet1D50(ResNet1D):
             block=keras_resnet.blocks.bottleneck_1d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -253,7 +253,7 @@ class ResNet1D101(ResNet1D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -269,7 +269,7 @@ class ResNet1D101(ResNet1D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 23, 3]
 
@@ -282,7 +282,7 @@ class ResNet1D101(ResNet1D):
             block=keras_resnet.blocks.bottleneck_1d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -300,7 +300,7 @@ class ResNet1D152(ResNet1D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -316,7 +316,7 @@ class ResNet1D152(ResNet1D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 8, 36, 3]
 
@@ -329,7 +329,7 @@ class ResNet1D152(ResNet1D):
             block=keras_resnet.blocks.bottleneck_1d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -347,7 +347,7 @@ class ResNet1D200(ResNet1D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -363,7 +363,7 @@ class ResNet1D200(ResNet1D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 24, 36, 3]
 
@@ -376,7 +376,7 @@ class ResNet1D200(ResNet1D):
             block=keras_resnet.blocks.bottleneck_1d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )

--- a/keras_resnet/models/_2d.py
+++ b/keras_resnet/models/_2d.py
@@ -27,7 +27,7 @@ class ResNet2D(tf.keras.Model):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :param numerical_names: list of bool, same size as blocks, used to indicate whether names of layers should include numbers or letters
 
@@ -57,7 +57,7 @@ class ResNet2D(tf.keras.Model):
         block,
         include_top=True,
         classes=1000,
-        freeze_bn=True,
+        trainable_bn=True,
         numerical_names=None,
         *args,
         **kwargs
@@ -70,8 +70,9 @@ class ResNet2D(tf.keras.Model):
         if numerical_names is None:
             numerical_names = [True] * len(blocks)
 
-        x = tf.keras.layers.Conv2D(64, (7, 7), strides=(2, 2), use_bias=False, name="conv1", padding="same")(inputs)
-        x = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn_conv1")(x)
+        x = tf.keras.layers.ZeroPadding2D(padding=3, name="padding_conv1")(inputs)
+        x = tf.keras.layers.Conv2D(64, (7, 7), strides=(2, 2), use_bias=False, name="conv1")(x)
+        x = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn_conv1")(x)
         x = tf.keras.layers.Activation("relu", name="conv1_relu")(x)
         x = tf.keras.layers.MaxPooling2D((3, 3), strides=(2, 2), padding="same", name="pool1")(x)
 
@@ -86,7 +87,7 @@ class ResNet2D(tf.keras.Model):
                     stage_id,
                     block_id,
                     numerical_name=(block_id > 0 and numerical_names[stage_id]),
-                    freeze_bn=freeze_bn
+                    trainable_bn=trainable_bn
                 )(x)
 
             features *= 2
@@ -117,7 +118,7 @@ class ResNet2D18(ResNet2D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -133,7 +134,7 @@ class ResNet2D18(ResNet2D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [2, 2, 2, 2]
 
@@ -143,7 +144,7 @@ class ResNet2D18(ResNet2D):
             block=keras_resnet.blocks.basic_2d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -161,7 +162,7 @@ class ResNet2D34(ResNet2D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -177,7 +178,7 @@ class ResNet2D34(ResNet2D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 6, 3]
 
@@ -187,7 +188,7 @@ class ResNet2D34(ResNet2D):
             block=keras_resnet.blocks.basic_2d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -205,7 +206,7 @@ class ResNet2D50(ResNet2D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -221,7 +222,7 @@ class ResNet2D50(ResNet2D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 6, 3]
 
@@ -234,7 +235,7 @@ class ResNet2D50(ResNet2D):
             block=keras_resnet.blocks.bottleneck_2d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -252,7 +253,7 @@ class ResNet2D101(ResNet2D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -268,7 +269,7 @@ class ResNet2D101(ResNet2D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 23, 3]
 
@@ -281,7 +282,7 @@ class ResNet2D101(ResNet2D):
             block=keras_resnet.blocks.bottleneck_2d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -299,7 +300,7 @@ class ResNet2D152(ResNet2D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -315,7 +316,7 @@ class ResNet2D152(ResNet2D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 8, 36, 3]
 
@@ -328,7 +329,7 @@ class ResNet2D152(ResNet2D):
             block=keras_resnet.blocks.bottleneck_2d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -346,7 +347,7 @@ class ResNet2D200(ResNet2D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -362,7 +363,7 @@ class ResNet2D200(ResNet2D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 24, 36, 3]
 
@@ -375,7 +376,7 @@ class ResNet2D200(ResNet2D):
             block=keras_resnet.blocks.bottleneck_2d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )

--- a/keras_resnet/models/_3d.py
+++ b/keras_resnet/models/_3d.py
@@ -27,7 +27,7 @@ class ResNet3D(tf.keras.Model):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :param numerical_names: list of bool, same size as blocks, used to indicate whether names of layers should include numbers or letters
 
@@ -57,7 +57,7 @@ class ResNet3D(tf.keras.Model):
         block,
         include_top=True,
         classes=1000,
-        freeze_bn=True,
+        trainable_bn=True,
         numerical_names=None,
         *args,
         **kwargs
@@ -72,7 +72,7 @@ class ResNet3D(tf.keras.Model):
 
         x = tf.keras.layers.ZeroPadding3D(padding=3, name="padding_conv1")(inputs)
         x = tf.keras.layers.Conv3D(64, (7, 7), strides=(2, 2), use_bias=False, name="conv1")(x)
-        x = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn_conv1")(x)
+        x = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn_conv1")(x)
         x = tf.keras.layers.Activation("relu", name="conv1_relu")(x)
         x = tf.keras.layers.MaxPooling3D((3, 3), strides=(2, 2), padding="same", name="pool1")(x)
 
@@ -87,7 +87,7 @@ class ResNet3D(tf.keras.Model):
                     stage_id,
                     block_id,
                     numerical_name=(block_id > 0 and numerical_names[stage_id]),
-                    freeze_bn=freeze_bn
+                    trainable_bn=trainable_bn
                 )(x)
 
             features *= 2
@@ -118,7 +118,7 @@ class ResNet3D18(ResNet3D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -134,7 +134,7 @@ class ResNet3D18(ResNet3D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [2, 2, 2, 2]
 
@@ -144,7 +144,7 @@ class ResNet3D18(ResNet3D):
             block=keras_resnet.blocks.basic_3d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -162,7 +162,7 @@ class ResNet3D34(ResNet3D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -178,7 +178,7 @@ class ResNet3D34(ResNet3D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 6, 3]
 
@@ -188,7 +188,7 @@ class ResNet3D34(ResNet3D):
             block=keras_resnet.blocks.basic_3d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -206,7 +206,7 @@ class ResNet3D50(ResNet3D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -222,7 +222,7 @@ class ResNet3D50(ResNet3D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 6, 3]
 
@@ -235,7 +235,7 @@ class ResNet3D50(ResNet3D):
             block=keras_resnet.blocks.bottleneck_3d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -253,7 +253,7 @@ class ResNet3D101(ResNet3D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -269,7 +269,7 @@ class ResNet3D101(ResNet3D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 23, 3]
 
@@ -282,7 +282,7 @@ class ResNet3D101(ResNet3D):
             block=keras_resnet.blocks.bottleneck_3d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -300,7 +300,7 @@ class ResNet3D152(ResNet3D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -316,7 +316,7 @@ class ResNet3D152(ResNet3D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 8, 36, 3]
 
@@ -329,7 +329,7 @@ class ResNet3D152(ResNet3D):
             block=keras_resnet.blocks.bottleneck_3d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )
@@ -347,7 +347,7 @@ class ResNet3D200(ResNet3D):
 
     :param classes: number of classes to classify (include_top must be true)
 
-    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
+    :param trainable_bn: if false, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -363,7 +363,7 @@ class ResNet3D200(ResNet3D):
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
     """
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, freeze_bn=False, *args, **kwargs):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, trainable_bn=True, *args, **kwargs):
         if blocks is None:
             blocks = [3, 24, 36, 3]
 
@@ -376,7 +376,7 @@ class ResNet3D200(ResNet3D):
             block=keras_resnet.blocks.bottleneck_3d,
             include_top=include_top,
             classes=classes,
-            freeze_bn=freeze_bn,
+            trainable_bn=trainable_bn,
             *args,
             **kwargs
         )

--- a/keras_resnet/models/_feature_pyramid_2d.py
+++ b/keras_resnet/models/_feature_pyramid_2d.py
@@ -19,7 +19,7 @@ class FPN2D(tf.keras.Model):
             inputs,
             blocks,
             block,
-            freeze_bn=True,
+            trainable_bn=True,
             numerical_names=None,
             *args,
             **kwargs
@@ -33,7 +33,7 @@ class FPN2D(tf.keras.Model):
             numerical_names = [True] * len(blocks)
 
         x = tf.keras.layers.Conv2D(64, (7, 7), strides=(2, 2), use_bias=False, name="conv1", padding="same")(inputs)
-        x = keras_resnet.layers.BatchNormalization(axis=axis, epsilon=1e-5, freeze=freeze_bn, name="bn_conv1")(x)
+        x = tf.keras.layers.BatchNormalization(axis=axis, epsilon=1e-5, trainable=trainable_bn, name="bn_conv1")(x)
         x = tf.keras.layers.Activation("relu", name="conv1_relu")(x)
         x = tf.keras.layers.MaxPooling2D((3, 3), strides=(2, 2), padding="same", name="pool1")(x)
 
@@ -48,7 +48,7 @@ class FPN2D(tf.keras.Model):
                     stage_id,
                     block_id,
                     numerical_name=(block_id > 0 and numerical_names[stage_id]),
-                    freeze_bn=freeze_bn
+                    trainable_bn=trainable_bn
                 )(x)
 
             features *= 2


### PR DESCRIPTION
Setting the `trainable` flag now also disables all updates for the BatchNormalization layer.

Source: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/layers/normalization_v2.py